### PR TITLE
LNX-86 Implement Entity serialization

### DIFF
--- a/lynx/common/enitity.py
+++ b/lynx/common/enitity.py
@@ -1,6 +1,34 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
 from lynx.common.serializable import Serializable
 
-# Right now it just represents common root
-# for both `Object` and `Action`
+
+# right now it just represents common root for both `Object` and `Action`
 class Entity(Serializable):
-    pass
+    @dataclass
+    class _Exported(Serializable):
+        type: str = ""
+        attributes: str = ""
+
+    def get_type(self) -> str:
+        return type(self).__name__
+
+    def get_attributes(self) -> str:
+        return super().serialize()
+
+    def serialize(self) -> str:
+        return self._Exported(self.get_type(), self.get_attributes()).serialize()
+
+    @classmethod
+    def deserialize(cls, json_string: str) -> Entity:
+        # we import every `Entity` type, so we can create instance of any of them when needed
+        # TODO: simplify following imports
+        from lynx.common.actions.move import Move
+        from lynx.common.object import Object
+
+        exported_entity = cls._Exported.deserialize(json_string)
+        entity_type = locals()[exported_entity.type]
+        entity = entity_type()
+        entity.populate(exported_entity.attributes)
+        return entity

--- a/lynx/common/serializable.py
+++ b/lynx/common/serializable.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+from typing import NoReturn, get_type_hints, get_args
 import json
-from typing import get_type_hints, get_args
 
 
 class Serializable:
@@ -8,7 +9,7 @@ class Serializable:
     string in format that can be easily deserialized by other microservices.
     """
 
-    def __init__(self) -> None:
+    def __init__(self) -> NoReturn:
         pass
 
     def __str__(self) -> str:
@@ -24,7 +25,7 @@ class Serializable:
     # This method is responsible for populating instance of an object
     # with data from `JSON`. Usually, `self` contains defaultly initialized
     # instance of the class
-    def populate(self, json_string) -> None:
+    def populate(self, json_string) -> NoReturn:
         json_data = json.loads(json_string)
         for exported_var in json_data.keys():
             # If deserialized object is a list
@@ -50,9 +51,13 @@ class Serializable:
                 self.__dict__[exported_var] = variable_type.deserialize(
                     json.dumps(json_data[exported_var]))
 
+    def post_populate(self) -> NoReturn:
+        pass
+
     @classmethod
-    def deserialize(cls, json_string: str):  # TODO: returning `Self` was not working
+    def deserialize(cls, json_string: str) -> Serializable:
         # All serializable classes must have parameterless constructor
         instance = cls()
         instance.populate(json_string)
+        instance.post_populate()
         return instance

--- a/tests/move_test.py
+++ b/tests/move_test.py
@@ -1,21 +1,28 @@
+from typing import NoReturn
+
 from lynx.common.actions.move import Move
 from lynx.common.enums import Direction
 
 
-def test_move_serialization():
-    move = Move(object_id=123, vector=Direction.NORTH.value)
-    serialized_move = move.serialize()
+def test_move_serialization_success() -> NoReturn:
+    expected_serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 123, \\"vector\\": {\\"x\\": 0, \\"y\\": 1}}"}'
+    serialized_move = Move(object_id=123, vector=Direction.NORTH.value).serialize()
+    assert serialized_move == expected_serialized_move
 
-    assert serialized_move == '{"object_id": 123, "vector": {"x": 0, "y": 1}}'
 
+def test_move_deserialization_success() -> NoReturn:
+    expected_deserialized_move = Move(object_id=123, vector=Direction.NORTH.value)
+
+    serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 123, \\"vector\\": {\\"x\\": 0, \\"y\\": 1}}"}'
     deserialized_move = Move.deserialize(serialized_move)
 
-    assert deserialized_move == move
+    assert deserialized_move == expected_deserialized_move
 
-def test_move_serialization_fail():
-    move = Move(object_id=123, vector=Direction.NORTH.value)
-    serialized_move = '{"object_id": 124, "vector": {"x": 0, "y": 1}}'
 
+def test_move_deserialization_failure() -> NoReturn:
+    expected_deserialized_move = Move(object_id=123, vector=Direction.NORTH.value)
+
+    serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 345, \\"vector\\": {\\"x\\": 1, \\"y\\": 2}}"}'
     deserialized_move = Move.deserialize(serialized_move)
 
-    assert (deserialized_move == move) == False
+    assert deserialized_move != expected_deserialized_move

--- a/tests/scene_test.py
+++ b/tests/scene_test.py
@@ -1,19 +1,19 @@
-import pytest
+from typing import NoReturn
+
 from lynx.common.actions.move import Move
 from lynx.common.object import Object
 from lynx.common.scene import Scene
 from lynx.common.vector import Vector
 
 
-def test_scene_serialization():
-    scene = Scene()
-    test_object = Object(id=3123, name="generic guy", position=Vector(5,321))
-    test_action = Move(object_id=3123, vector=Vector(1,1))
-    scene.add_object(test_object)
-    scene.add_entity(test_action)
-    
-    serialized_scene = scene.serialize()
+def test_scene_deserialization_success() -> NoReturn:
+    expected_scene = Scene()
+    dummy_object = Object(id=123, name="dummy", position=Vector(0, 0))
+    dummy_action = Move(object_id=456, vector=Vector(1, 1))
+    expected_scene.add_entity(dummy_object)
+    expected_scene.add_entity(dummy_action)
+    serialized_expected_scene = expected_scene.serialize()
 
-    deserialzied_scene = Scene.deserialize(serialized_scene)
+    deserialzied_scene = Scene.deserialize(serialized_expected_scene)
 
-    assert scene == deserialzied_scene
+    assert deserialzied_scene == expected_scene


### PR DESCRIPTION
Changes:
* simplified `Scene` & `Entity` exports
* simplified `Scene` serialization
* removed `add_object`, moved its logic to `add_entity` - should be less confusing now (thanks for heads-up @Krystian030)