### PR TITLE
LNX-87 Add tests for critical structures

### DIFF
--- a/tests/move_test.py
+++ b/tests/move_test.py
@@ -4,25 +4,30 @@ from lynx.common.actions.move import Move
 from lynx.common.enums import Direction
 
 
-def test_move_serialization_success() -> NoReturn:
+class TestMoveSerialization:
     expected_serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 123, \\"vector\\": {\\"x\\": 0, \\"y\\": 1}}"}'
-    serialized_move = Move(object_id=123, vector=Direction.NORTH.value).serialize()
-    assert serialized_move == expected_serialized_move
+
+    def test_success(self) -> NoReturn:
+
+        serialized_move = Move(object_id=123, vector=Direction.NORTH.value).serialize()
+        assert serialized_move == self.expected_serialized_move
+
+    def test_failure(self) -> NoReturn:
+        serialized_move = Move(object_id=345, vector=Direction.WEST.value).serialize()
+        assert serialized_move != self.expected_serialized_move
 
 
-def test_move_deserialization_success() -> NoReturn:
+class TestMoveDeserialization:
     expected_deserialized_move = Move(object_id=123, vector=Direction.NORTH.value)
 
-    serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 123, \\"vector\\": {\\"x\\": 0, \\"y\\": 1}}"}'
-    deserialized_move = Move.deserialize(serialized_move)
+    def test_success(self) -> NoReturn:
+        serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 123, \\"vector\\": {\\"x\\": 0, \\"y\\": 1}}"}'
+        deserialized_move = Move.deserialize(serialized_move)
 
-    assert deserialized_move == expected_deserialized_move
+        assert deserialized_move == self.expected_deserialized_move
 
+    def test_failure(self) -> NoReturn:
+        serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 345, \\"vector\\": {\\"x\\": 1, \\"y\\": 2}}"}'
+        deserialized_move = Move.deserialize(serialized_move)
 
-def test_move_deserialization_failure() -> NoReturn:
-    expected_deserialized_move = Move(object_id=123, vector=Direction.NORTH.value)
-
-    serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 345, \\"vector\\": {\\"x\\": 1, \\"y\\": 2}}"}'
-    deserialized_move = Move.deserialize(serialized_move)
-
-    assert deserialized_move != expected_deserialized_move
+        assert deserialized_move != self.expected_deserialized_move

--- a/tests/scene_test.py
+++ b/tests/scene_test.py
@@ -6,14 +6,54 @@ from lynx.common.scene import Scene
 from lynx.common.vector import Vector
 
 
-def test_scene_deserialization_success() -> NoReturn:
-    expected_scene = Scene()
+class TestSceneSerialization:
+    expected_serialized_scene = '{"entities": [{"type": "Object", "attributes": "{\\"id\\": 123, \\"name\\": \\"dummy\\", \\"position\\": {\\"x\\": ' \
+                                '0, \\"y\\": 0}, \\"additional_positions\\": [], \\"state\\": \\"\\", \\"walkable\\": false, \\"tick\\": \\"\\", ' \
+                                '\\"on_death\\": \\"\\", \\"owner\\": \\"\\"}"}, {"type": "Move", "attributes": "{\\"object_id\\": 456, ' \
+                                '\\"vector\\": {\\"x\\": 1, \\"y\\": 1}}"}]}'
+
+    def test_success(self) -> NoReturn:
+        scene = Scene()
+        dummy_object = Object(id=123, name="dummy", position=Vector(0, 0))
+        dummy_action = Move(object_id=456, vector=Vector(1, 1))
+        scene.add_entity(dummy_object)
+        scene.add_entity(dummy_action)
+        serialized_scene = scene.serialize()
+
+        assert serialized_scene == self.expected_serialized_scene
+
+    def test_failure(self) -> NoReturn:
+        scene = Scene()
+        dummy_object = Object(id=789, name="dummy", position=Vector(0, 0))
+        dummy_action = Move(object_id=1011, vector=Vector(1, 1))
+        scene.add_entity(dummy_object)
+        scene.add_entity(dummy_action)
+        serialized_scene = scene.serialize()
+
+        assert serialized_scene != self.expected_serialized_scene
+
+
+class TestSceneDeserialization:
+    expected_deserialized_scene = Scene()
     dummy_object = Object(id=123, name="dummy", position=Vector(0, 0))
     dummy_action = Move(object_id=456, vector=Vector(1, 1))
-    expected_scene.add_entity(dummy_object)
-    expected_scene.add_entity(dummy_action)
-    serialized_expected_scene = expected_scene.serialize()
+    expected_deserialized_scene.add_entity(dummy_object)
+    expected_deserialized_scene.add_entity(dummy_action)
 
-    deserialzied_scene = Scene.deserialize(serialized_expected_scene)
+    def test_success(self) -> NoReturn:
+        serialized_scene = '{"entities": [{"type": "Object", "attributes": "{\\"id\\": 123, \\"name\\": \\"dummy\\", \\"position\\": {\\"x\\": 0, ' \
+                           '\\"y\\": 0}, \\"additional_positions\\": [], \\"state\\": \\"\\", \\"walkable\\": false, \\"tick\\": \\"\\", ' \
+                           '\\"on_death\\": \\"\\", \\"owner\\": \\"\\"}"}, {"type": "Move", "attributes": "{\\"object_id\\": 456, \\"vector\\": {' \
+                           '\\"x\\": 1, \\"y\\": 1}}"}]}'
+        deserialzied_scene = Scene.deserialize(serialized_scene)
 
-    assert deserialzied_scene == expected_scene
+        assert deserialzied_scene == self.expected_deserialized_scene
+
+    def test_failure(self) -> NoReturn:
+        serialized_scene = '{"entities": [{"type": "Object", "attributes": "{\\"id\\": 789, \\"name\\": \\"dummy\\", \\"position\\": {\\"x\\": 0, ' \
+                           '\\"y\\": 0}, \\"additional_positions\\": [], \\"state\\": \\"\\", \\"walkable\\": false, \\"tick\\": \\"\\", ' \
+                           '\\"on_death\\": \\"\\", \\"owner\\": \\"\\"}"}, {"type": "Move", "attributes": "{\\"object_id\\": 1011, \\"vector\\": {' \
+                           '\\"x\\": 1, \\"y\\": 1}}"}]}'
+        deserialzied_scene = Scene.deserialize(serialized_scene)
+
+        assert deserialzied_scene != self.expected_deserialized_scene


### PR DESCRIPTION
Changes:
* added missing tests for false positives - now almost every test checks for success and failure (`test_success`, `test_failure`)
* grouped tests into classes - it is a `pytest` convention
* added test checking if classes inheriting from `Serializable` have access to parameterless constructors, as **they are a must-have** (requires maintenance of adding new classes until we figure out dynamic imports)
* adapted all tests to AAA (Arrange, Act, Assert) - we arrange what is expected, act on the code we are testing and assert results