### PR TITLE
LNX-83-create-generic-requirements

### DIFF
--- a/lynx/common/actions/action.py
+++ b/lynx/common/actions/action.py
@@ -1,4 +1,7 @@
+from typing import Callable, List
+
 from lynx.common.enitity import Entity
+
 
 class Action(Entity):
     """
@@ -11,4 +14,9 @@ class Action(Entity):
     def apply(self, scene: 'Scene') -> None:
         """
         Method used to change state of a `scene`
+        """
+
+    def requirements(self) -> List[Callable[['Scene'], bool]]:
+        """
+        Method return all requirements needed to apply changes
         """

--- a/lynx/common/actions/action.py
+++ b/lynx/common/actions/action.py
@@ -16,7 +16,7 @@ class Action(Entity):
         Method used to change state of a `scene`
         """
 
-    def requirements(self) -> List[Callable[['Scene'], bool]]:
+    def satisfies_requirements(self) -> bool:
         """
-        Method return all requirements needed to apply changes
+        Method returns all requirements needed to apply changes
         """

--- a/lynx/common/actions/common_requirements.py
+++ b/lynx/common/actions/common_requirements.py
@@ -1,0 +1,19 @@
+from typing import Callable
+
+from lynx.common.object import Object
+from lynx.common.vector import Vector
+
+
+class CommonRequirements:
+
+    @staticmethod
+    def is_walkable_destination(object_id: int, vector: Vector):
+        def requirement(scene: 'Scene') -> Callable[['Scene'], bool]:
+            object: Object = scene.get_object_by_id(object_id)
+            destination_position: Vector = object.position + vector
+            object_at_destination: Object = scene.get_object_by_position(destination_position)
+            return object_at_destination is not None and object_at_destination.walkable
+
+        return requirement
+
+

--- a/lynx/common/actions/common_requirements.py
+++ b/lynx/common/actions/common_requirements.py
@@ -1,5 +1,3 @@
-from typing import Callable
-
 from lynx.common.object import Object
 from lynx.common.vector import Vector
 
@@ -7,13 +5,8 @@ from lynx.common.vector import Vector
 class CommonRequirements:
 
     @staticmethod
-    def is_walkable_destination(object_id: int, vector: Vector):
-        def requirement(scene: 'Scene') -> Callable[['Scene'], bool]:
-            object: Object = scene.get_object_by_id(object_id)
-            destination_position: Vector = object.position + vector
-            object_at_destination: Object = scene.get_object_by_position(destination_position)
-            return object_at_destination is not None and object_at_destination.walkable
-
-        return requirement
-
-
+    def is_walkable(scene: 'Scene', object_id: int, movement: Vector) -> bool:
+        object: Object = scene.get_object_by_id(object_id)
+        destination_position: Vector = object.position + movement
+        object_at_destination: Object = scene.get_object_by_position(destination_position)
+        return object_at_destination is not None and object_at_destination.walkable

--- a/lynx/common/actions/move.py
+++ b/lynx/common/actions/move.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List, Callable
 
 from lynx.common.actions.action import Action
 from lynx.common.actions.common_requirements import CommonRequirements
@@ -14,11 +13,11 @@ class Move(Action):
     in case the movement was not possible(destination is not walkable etc).
     """
     object_id: int = -1
-    vector: Vector = Vector(0, 0)
+    movement: Vector = Vector(0, 0)
 
-    def requirements(self) -> List[Callable[['Scene'], bool]]:
-        return [CommonRequirements.is_walkable_destination(self.object_id, self.vector)]
+    def satisfies_requirements(self, scene: 'Scene') -> bool:
+        return CommonRequirements.is_walkable(scene, self.object_id, self.movement)
 
     def apply(self, scene: 'Scene') -> None:
         object: Object = scene.get_object_by_id(self.object_id)
-        scene.move_object(object, self.vector)
+        scene.move_object(object, self.movement)

--- a/lynx/common/actions/move.py
+++ b/lynx/common/actions/move.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
+from typing import List, Callable
 
 from lynx.common.actions.action import Action
+from lynx.common.actions.common_requirements import CommonRequirements
 from lynx.common.object import Object
 from lynx.common.vector import Vector
 
@@ -13,6 +15,9 @@ class Move(Action):
     """
     object_id: int = -1
     vector: Vector = Vector(0, 0)
+
+    def requirements(self) -> List[Callable[['Scene'], bool]]:
+        return [CommonRequirements.is_walkable_destination(self.object_id, self.vector)]
 
     def apply(self, scene: 'Scene') -> None:
         object: Object = scene.get_object_by_id(self.object_id)

--- a/lynx/common/scene.py
+++ b/lynx/common/scene.py
@@ -1,7 +1,5 @@
-from dataclasses import dataclass
-from typing import Dict, List, NoReturn, Union
+from typing import Dict, NoReturn, Optional
 
-from lynx.common.enitity import Entity
 from lynx.common.object import *
 from lynx.common.serializable import Serializable
 from lynx.common.vector import Vector
@@ -25,12 +23,12 @@ class Scene(Serializable):
             self._object_position_map[entity.position] = entity
             self._object_id_map[entity.id] = entity
 
-    def get_object_by_id(self, id: int) -> Union[Object, None]:
+    def get_object_by_id(self, id: int) -> Optional[Object]:
         return self._object_id_map.get(id)
-    
-    def get_object_by_position(self, position: Vector) -> Union[Object, None]:
+
+    def get_object_by_position(self, position: Vector) -> Optional[Object]:
         return self._object_map.get(position)
-    
+
     def move_object(self, object: Object, vector: Vector) -> NoReturn:
         self._object_position_map[object.position] = None
         object.position = object.position + vector

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/bin/python
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name="lynx-python-common",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/bin/python
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 setup(
     name="lynx-python-common",

--- a/tests/common_requirements_test.py
+++ b/tests/common_requirements_test.py
@@ -1,12 +1,11 @@
-import unittest
-from typing import NoReturn, Callable
+from typing import NoReturn
 from unittest.mock import patch, MagicMock
 
 from lynx.common.actions.common_requirements import CommonRequirements
 from lynx.common.vector import Vector
 
 
-class TestIsWalkableDestination(unittest.TestCase):
+class TestIsWalkable:
 
     @patch('lynx.common.scene.Scene')
     def test_success(self, mock_scene) -> NoReturn:
@@ -15,16 +14,14 @@ class TestIsWalkableDestination(unittest.TestCase):
         )
         mock_scene.get_object_by_position.return_value = mock_object_at_destination
 
-        requirement: Callable = CommonRequirements.is_walkable_destination(1, Vector(1, 0))
-        result = requirement(mock_scene)
+        result: bool = CommonRequirements.is_walkable(mock_scene, 1, Vector(1, 0))
 
-        self.assertTrue(result)
+        assert result is True
 
     @patch('lynx.common.scene.Scene')
     def test_failure(self, mock_scene) -> NoReturn:
         mock_scene.get_object_by_position.return_value = None
 
-        requirement: Callable = CommonRequirements.is_walkable_destination(1, Vector(1, 0))
-        result = requirement(mock_scene)
+        result: bool = CommonRequirements.is_walkable(mock_scene, 1, Vector(1, 0))
 
-        self.assertFalse(result)
+        assert result is False

--- a/tests/common_requirements_test.py
+++ b/tests/common_requirements_test.py
@@ -1,0 +1,30 @@
+import unittest
+from typing import NoReturn, Callable
+from unittest.mock import patch, MagicMock
+
+from lynx.common.actions.common_requirements import CommonRequirements
+from lynx.common.vector import Vector
+
+
+class TestIsWalkableDestination(unittest.TestCase):
+
+    @patch('lynx.common.scene.Scene')
+    def test_success(self, mock_scene) -> NoReturn:
+        mock_object_at_destination = MagicMock(
+            walkable=True
+        )
+        mock_scene.get_object_by_position.return_value = mock_object_at_destination
+
+        requirement: Callable = CommonRequirements.is_walkable_destination(1, Vector(1, 0))
+        result = requirement(mock_scene)
+
+        self.assertTrue(result)
+
+    @patch('lynx.common.scene.Scene')
+    def test_failure(self, mock_scene) -> NoReturn:
+        mock_scene.get_object_by_position.return_value = None
+
+        requirement: Callable = CommonRequirements.is_walkable_destination(1, Vector(1, 0))
+        result = requirement(mock_scene)
+
+        self.assertFalse(result)

--- a/tests/move_test.py
+++ b/tests/move_test.py
@@ -1,3 +1,4 @@
+import unittest
 from typing import NoReturn
 
 from lynx.common.actions.move import Move
@@ -7,7 +8,7 @@ from lynx.common.scene import Scene
 from lynx.common.vector import Vector
 
 
-class TestMoveSerialization:
+class TestMoveSerialization(unittest.TestCase):
     expected_serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 123, \\"vector\\": {\\"x\\": 0, \\"y\\": 1}}"}'
 
     def test_success(self) -> NoReturn:
@@ -20,7 +21,7 @@ class TestMoveSerialization:
         assert serialized_move != self.expected_serialized_move
 
 
-class TestMoveDeserialization:
+class TestMoveDeserialization(unittest.TestCase):
     expected_deserialized_move = Move(object_id=123, vector=Direction.NORTH.value)
 
     def test_success(self) -> NoReturn:
@@ -35,7 +36,7 @@ class TestMoveDeserialization:
 
         assert deserialized_move != self.expected_deserialized_move
 
-class TestMoveApply:
+class TestMoveApply(unittest.TestCase):
 
     def test_apply(self) -> NoReturn:
         expected_scene = Scene()
@@ -57,3 +58,16 @@ class TestMoveApply:
         scene._object_position_map = {k: v for k, v in scene._object_position_map.items() if v is not None}
 
         assert scene == expected_scene
+
+class TestMoveRequirements(unittest.TestCase):
+
+    def test_success(self):
+        dummy_action = Move(
+            object_id=123,
+            vector=Vector(1,1)
+        )
+
+        number_requirements = len(dummy_action.requirements())
+
+        self.assertEquals(number_requirements, 1)
+

--- a/tests/scene_test.py
+++ b/tests/scene_test.py
@@ -10,12 +10,12 @@ class TestSceneSerialization:
     expected_serialized_scene = '{"entities": [{"type": "Object", "attributes": "{\\"id\\": 123, \\"name\\": \\"dummy\\", \\"position\\": {\\"x\\": ' \
                                 '0, \\"y\\": 0}, \\"additional_positions\\": [], \\"state\\": \\"\\", \\"walkable\\": false, \\"tick\\": \\"\\", ' \
                                 '\\"on_death\\": \\"\\", \\"owner\\": \\"\\"}"}, {"type": "Move", "attributes": "{\\"object_id\\": 456, ' \
-                                '\\"vector\\": {\\"x\\": 1, \\"y\\": 1}}"}]}'
+                                '\\"movement\\": {\\"x\\": 1, \\"y\\": 1}}"}]}'
 
     def test_success(self) -> NoReturn:
         scene = Scene()
         dummy_object = Object(id=123, name="dummy", position=Vector(0, 0))
-        dummy_action = Move(object_id=456, vector=Vector(1, 1))
+        dummy_action = Move(object_id=456, movement=Vector(1, 1))
         scene.add_entity(dummy_object)
         scene.add_entity(dummy_action)
         serialized_scene = scene.serialize()
@@ -25,7 +25,7 @@ class TestSceneSerialization:
     def test_failure(self) -> NoReturn:
         scene = Scene()
         dummy_object = Object(id=789, name="dummy", position=Vector(0, 0))
-        dummy_action = Move(object_id=1011, vector=Vector(1, 1))
+        dummy_action = Move(object_id=1011, movement=Vector(1, 1))
         scene.add_entity(dummy_object)
         scene.add_entity(dummy_action)
         serialized_scene = scene.serialize()
@@ -36,14 +36,14 @@ class TestSceneSerialization:
 class TestSceneDeserialization:
     expected_deserialized_scene = Scene()
     dummy_object = Object(id=123, name="dummy", position=Vector(0, 0))
-    dummy_action = Move(object_id=456, vector=Vector(1, 1))
+    dummy_action = Move(object_id=456, movement=Vector(1, 1))
     expected_deserialized_scene.add_entity(dummy_object)
     expected_deserialized_scene.add_entity(dummy_action)
 
     def test_success(self) -> NoReturn:
         serialized_scene = '{"entities": [{"type": "Object", "attributes": "{\\"id\\": 123, \\"name\\": \\"dummy\\", \\"position\\": {\\"x\\": 0, ' \
                            '\\"y\\": 0}, \\"additional_positions\\": [], \\"state\\": \\"\\", \\"walkable\\": false, \\"tick\\": \\"\\", ' \
-                           '\\"on_death\\": \\"\\", \\"owner\\": \\"\\"}"}, {"type": "Move", "attributes": "{\\"object_id\\": 456, \\"vector\\": {' \
+                           '\\"on_death\\": \\"\\", \\"owner\\": \\"\\"}"}, {"type": "Move", "attributes": "{\\"object_id\\": 456, \\"movement\\": {' \
                            '\\"x\\": 1, \\"y\\": 1}}"}]}'
         deserialzied_scene = Scene.deserialize(serialized_scene)
 
@@ -52,7 +52,7 @@ class TestSceneDeserialization:
     def test_failure(self) -> NoReturn:
         serialized_scene = '{"entities": [{"type": "Object", "attributes": "{\\"id\\": 789, \\"name\\": \\"dummy\\", \\"position\\": {\\"x\\": 0, ' \
                            '\\"y\\": 0}, \\"additional_positions\\": [], \\"state\\": \\"\\", \\"walkable\\": false, \\"tick\\": \\"\\", ' \
-                           '\\"on_death\\": \\"\\", \\"owner\\": \\"\\"}"}, {"type": "Move", "attributes": "{\\"object_id\\": 1011, \\"vector\\": {' \
+                           '\\"on_death\\": \\"\\", \\"owner\\": \\"\\"}"}, {"type": "Move", "attributes": "{\\"object_id\\": 1011, \\"movement\\": {' \
                            '\\"x\\": 1, \\"y\\": 1}}"}]}'
         deserialzied_scene = Scene.deserialize(serialized_scene)
 


### PR DESCRIPTION
- Common requirements package has been created 
- The `requirements` method has been added to the action interface, which returns a list of requirements that need to be met
- Unit tests have been added
- The first requirement for the move action has been added. More requirements will add after creating generic actions.

How does it work?
Example for Move action. Here, we define the requirements function as follows:
```
  def requirements(self) -> List[Callable[['Scene'], bool]]:
        return [CommonRequirements.is_walkable_destination(self.object_id, self.vector)]
``` 
Inside `CommonRequirements`, we can define requirements for all actions, like so:
```
   @staticmethod
    def is_walkable_destination(object_id: int, vector: Vector):
        def requirement(scene: 'Scene') -> Callable[['Scene'], bool]:
            object: Object = scene.get_object_by_id(object_id)
            destination_position: Vector = object.position + vector
            object_at_destination: Object = scene.get_object_by_position(destination_position)
            return object_at_destination is not None and object_at_destination.walkable

        return requirement
```
If we want the requirement to apply only to our action, we can define it in our `Action` class as follows:
```
  def requirements(self) -> List[Callable[['Scene'], bool]]:
        def requirement(scene: 'Scene') -> Callable[['Scene'], bool]:
            object: Object = scene.get_object_by_id(self.object_id)
            destination_position: Vector = object.position + self.vector
            object_at_destination: Object = scene.get_object_by_position(destination_position)
            return object_at_destination is not None and object_at_destination.walkable
 
        return [requirement]
``` 