### PR TITLE
Serialize entity attributes as dict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__/
+build/
+lynx_python_common.egg-info/
 *.py[cod]
 *$py.class
 .*

--- a/lynx/common/enitity.py
+++ b/lynx/common/enitity.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from lynx.common.serializable import Serializable
 
@@ -9,13 +9,13 @@ class Entity(Serializable):
     @dataclass
     class _Exported(Serializable):
         type: str = ""
-        attributes: str = ""
+        attributes: dict = field(default_factory=dict)
 
     def get_type(self) -> str:
         return type(self).__name__
 
     def get_attributes(self) -> str:
-        return super().serialize()
+        return super()
 
     def serialize(self) -> str:
         return self._Exported(self.get_type(), self.get_attributes()).serialize()

--- a/lynx/common/enitity.py
+++ b/lynx/common/enitity.py
@@ -14,8 +14,8 @@ class Entity(Serializable):
     def get_type(self) -> str:
         return type(self).__name__
 
-    def get_attributes(self) -> str:
-        return super()
+    def get_attributes(self) -> dict:
+        return vars(self)
 
     def serialize(self) -> str:
         return self._Exported(self.get_type(), self.get_attributes()).serialize()

--- a/lynx/common/enitity.py
+++ b/lynx/common/enitity.py
@@ -14,11 +14,8 @@ class Entity(Serializable):
     def get_type(self) -> str:
         return type(self).__name__
 
-    def get_attributes(self) -> dict:
-        return vars(self)
-
     def serialize(self) -> str:
-        return self._Exported(self.get_type(), self.get_attributes()).serialize()
+        return self._Exported(self.get_type(), self.__dict__).serialize()
 
     @classmethod
     def deserialize(cls, json_string: str) -> Entity:

--- a/lynx/common/serializable.py
+++ b/lynx/common/serializable.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Union
 
 import json
 from typing import NoReturn, get_args, get_type_hints
@@ -26,8 +27,7 @@ class Serializable:
     # This method is responsible for populating instance of an object
     # with data from `JSON`. Usually, `self` contains defaultly initialized
     # instance of the class
-    def populate(self, json_string) -> NoReturn:
-        json_data = json.loads(json_string)
+    def populate(self, json_data) -> NoReturn:
         for exported_var in json_data.keys():
             # If deserialized object is a list
             if type(self.__dict__[exported_var]) == list:
@@ -42,23 +42,25 @@ class Serializable:
                 else:
                     for serialized_element in json_data[exported_var]:
                         self.__dict__[exported_var].append(
-                            element_type.deserialize(json.dumps(serialized_element)))
+                            element_type.deserialize(serialized_element))
             # If object we are deserializing is primitive
             elif not hasattr(self.__dict__[exported_var], '__dict__'):
                 self.__dict__[exported_var] = json_data[exported_var]
             # Deserialzied object is a class
             else:
                 variable_type = type(self.__dict__[exported_var])
-                self.__dict__[exported_var] = variable_type.deserialize(
-                    json.dumps(json_data[exported_var]))
+                self.__dict__[exported_var] = variable_type.deserialize(json_data[exported_var])
 
     def post_populate(self) -> NoReturn:
         pass
 
     @classmethod
-    def deserialize(cls, json_string: str) -> Serializable:
+    def deserialize(cls, json_data: Union[dict, str]) -> Serializable:
+        if json_data is str:
+            json_data = json.loads(json_data)
+
         # All serializable classes must have parameterless constructor
         instance = cls()
-        instance.populate(json_string)
+        instance.populate(json_data)
         instance.post_populate()
         return instance

--- a/lynx/common/serializable.py
+++ b/lynx/common/serializable.py
@@ -56,7 +56,7 @@ class Serializable:
 
     @classmethod
     def deserialize(cls, json_data: Union[dict, str]) -> Serializable:
-        if json_data is str:
+        if isinstance(json_data, str):
             json_data = json.loads(json_data)
 
         # All serializable classes must have parameterless constructor

--- a/tests/chop_test.py
+++ b/tests/chop_test.py
@@ -9,7 +9,7 @@ from lynx.common.vector import Vector
 import random
 
 class TestChopSerialization:
-	expected_serialization_chop = '{"type": "Chop", "attributes": "{\\"object_id\\": 1, \\"target_position\\": {\\"x\\": 2, \\"y\\": 2}}"}'
+	expected_serialization_chop = '{"type": "Chop", "attributes": {"object_id": 1, "target_position": {"x": 2, "y": 2}}}'
 
 	def test_success_serialization(self) -> NoReturn:
 		serialized_chop = Chop(object_id=1, target_position=Vector(2, 2)).serialize()

--- a/tests/move_test.py
+++ b/tests/move_test.py
@@ -10,7 +10,7 @@ from lynx.common.vector import Vector
 
 
 class TestMoveSerialization:
-    expected_serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 123, \\"movement\\": {\\"x\\": 0, \\"y\\": 1}}"}'
+    expected_serialized_move = '{"type": "Move", "attributes": {"object_id": 123, "movement": {"x": 0, "y": 1}}}'
 
     def test_success(self) -> NoReturn:
         serialized_move = Move(

--- a/tests/move_test.py
+++ b/tests/move_test.py
@@ -1,3 +1,4 @@
+import json
 from typing import NoReturn
 from unittest.mock import patch, MagicMock
 
@@ -28,14 +29,14 @@ class TestMoveDeserialization:
         object_id=123, movement=Direction.NORTH.value)
 
     def test_success(self) -> NoReturn:
-        serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 123, \\"movement\\": {\\"x\\": 0, \\"y\\": 1}}"}'
-        deserialized_move = Move.deserialize(serialized_move)
+        serialized_move = '{"type": "Move", "attributes": {"object_id": 123, "movement": {"x": 0, "y": 1}}}'
+        deserialized_move = Move.deserialize(json.loads(serialized_move))
 
         assert deserialized_move == self.expected_deserialized_move
 
     def test_failure(self) -> NoReturn:
-        serialized_move = '{"type": "Move", "attributes": "{\\"object_id\\": 345, \\"movement\\": {\\"x\\": 1, \\"y\\": 2}}"}'
-        deserialized_move = Move.deserialize(serialized_move)
+        serialized_move = '{"type": "Move", "attributes": {"object_id": 123, "movement": {"x": 1, "y": 2}}}'
+        deserialized_move = Move.deserialize(json.loads(serialized_move))
 
         assert deserialized_move != self.expected_deserialized_move
 

--- a/tests/push_test.py
+++ b/tests/push_test.py
@@ -8,8 +8,8 @@ from lynx.common.vector import Vector
 
 
 class TestPushSerialization:
-    expected_serialized_push = '{"type": "Push", "attributes": "{\\"object_id\\": 123, \\"direction\\": {\\"x\\": -1, \\"y\\": 0}, ' \
-                               '\\"pushed_object_ids\\": [1, 2, 3]}"}'
+    expected_serialized_push = '{"type": "Push", "attributes": {"object_id": 123, "direction": {"x": -1, "y": 0}, ' \
+                               '"pushed_object_ids": [1, 2, 3]}}'
 
     def test_success(self) -> NoReturn:
         push = Push(object_id=123, direction=Direction.WEST.value)
@@ -29,15 +29,15 @@ class TestPushDeserialization:
     expected_deserialized_push.pushed_object_ids = [1, 2, 3]
 
     def test_success(self) -> NoReturn:
-        serialized_push = '{"type": "Push", "attributes": "{\\"object_id\\": 123, \\"direction\\": {\\"x\\": -1, \\"y\\": 0}, ' \
-                          '\\"pushed_object_ids\\": [1, 2, 3]}"}'
+        serialized_push = '{"type": "Push", "attributes": {"object_id": 123, "direction": {"x": -1, "y": 0}, ' \
+                          '"pushed_object_ids": [1, 2, 3]}}'
         deserialized_push = Push.deserialize(serialized_push)
 
         assert deserialized_push == self.expected_deserialized_push
 
     def test_failure(self) -> NoReturn:
-        serialized_push = '{"type": "Push", "attributes": "{\\"object_id\\": 456, \\"direction\\": {\\"x\\": 1, \\"y\\": 0}, ' \
-                          '\\"pushed_object_ids\\": [4, 5, 6]}"}'
+        serialized_push = '{"type": "Push", "attributes": {"object_id": 456, "direction": {"x": 1, "y": 0}, ' \
+                          '"pushed_object_ids": [4, 5, 6]}}'
         deserialized_push = Push.deserialize(serialized_push)
 
         assert deserialized_push != self.expected_deserialized_push

--- a/tests/scene_test.py
+++ b/tests/scene_test.py
@@ -7,12 +7,10 @@ from lynx.common.vector import Vector
 
 
 class TestSceneSerialization:
-    expected_serialized_scene = '{"entities": [{"type": "Object", "attributes": "{\\"id\\": 123, \\"name\\": ' \
-                                '\\"dummy\\", \\"position\\": {\\"x\\": 0, \\"y\\": 0}, ' \
-                                '\\"additional_positions\\": [], \\"state\\": \\"\\", \\"walkable\\": false, ' \
-                                '\\"tick\\": \\"\\", \\"on_death\\": \\"\\", \\"owner\\": \\"\\", ' \
-                                '\\"pickable\\": false, \\"pushable\\": false}"}, {"type": "Move", "attributes": "{\\"object_id\\": 456,' \
-                                ' \\"movement\\": {\\"x\\": 1, \\"y\\": 1}}"}], "pending_actions": []}'
+    expected_serialized_scene = '{"entities": [{"type": "Object", "attributes": {"id": 123, "name": "dummy", "position": {"x": 0, "y": 0}, ' \
+                                '"additional_positions": [], "state": "", "walkable": false, "tick": "", ' \
+                                '"on_death": "", "owner": ""}}, {"type": "Move", "attributes": {"object_id": 456, '\
+                                '"movement": {"x": 1, "y": 1}}}]}'
 
     def test_success(self) -> NoReturn:
         scene = Scene()

--- a/tests/scene_test.py
+++ b/tests/scene_test.py
@@ -10,8 +10,8 @@ from lynx.common.vector import Vector
 class TestSceneSerialization:
     expected_serialized_scene = '{"entities": [{"type": "Object", "attributes": {"id": 123, "name": "dummy", "position": {"x": ' \
                                 '0, "y": 0}, "additional_positions": [], "state": "", "walkable": false, "tick": "", ' \
-                                '"on_death": "", "owner": ""}}, {"type": "Move", "attributes": {"object_id": 456, ' \
-                                '"movement": {"x": 1, "y": 1}}}]}'
+                                '"on_death": "", "owner": "", "pickable": false, "pushable": false}}, {"type": "Move", "attributes": {"object_id": 456, ' \
+                                '"movement": {"x": 1, "y": 1}}}], "pending_actions": []}'
 
     def test_success(self) -> NoReturn:
         scene = Scene()

--- a/tests/scene_test.py
+++ b/tests/scene_test.py
@@ -1,3 +1,4 @@
+import json
 from typing import NoReturn
 
 from lynx.common.actions.move import Move
@@ -7,9 +8,9 @@ from lynx.common.vector import Vector
 
 
 class TestSceneSerialization:
-    expected_serialized_scene = '{"entities": [{"type": "Object", "attributes": {"id": 123, "name": "dummy", "position": {"x": 0, "y": 0}, ' \
-                                '"additional_positions": [], "state": "", "walkable": false, "tick": "", ' \
-                                '"on_death": "", "owner": ""}}, {"type": "Move", "attributes": {"object_id": 456, '\
+    expected_serialized_scene = '{"entities": [{"type": "Object", "attributes": {"id": 123, "name": "dummy", "position": {"x": ' \
+                                '0, "y": 0}, "additional_positions": [], "state": "", "walkable": false, "tick": "", ' \
+                                '"on_death": "", "owner": ""}}, {"type": "Move", "attributes": {"object_id": 456, ' \
                                 '"movement": {"x": 1, "y": 1}}}]}'
 
     def test_success(self) -> NoReturn:
@@ -42,19 +43,17 @@ class TestSceneDeserialization:
     expected_deserialized_scene.add_entity(dummy_action)
 
     def test_success(self) -> NoReturn:
-        serialized_scene = '{"entities": [{"type": "Object", "attributes": "{\\"id\\": 123, \\"name\\": \\"dummy\\", \\"position\\": {\\"x\\": 0, ' \
-                           '\\"y\\": 0}, \\"additional_positions\\": [], \\"state\\": \\"\\", \\"walkable\\": false, \\"tick\\": \\"\\", ' \
-                           '\\"on_death\\": \\"\\", \\"owner\\": \\"\\"}"}, {"type": "Move", "attributes": "{\\"object_id\\": 456, \\"movement\\": {' \
-                           '\\"x\\": 1, \\"y\\": 1}}"}]}'
-        deserialzied_scene = Scene.deserialize(serialized_scene)
+        serialized_scene = '{"entities": [{"type": "Object", "attributes": {"id": 123, "name": "dummy", "position": {"x": 0, "y": 0}, ' \
+                           '"additional_positions": [], "state": "", "walkable": false, "tick": "", "on_death": "", "owner": ""}}, {"type": "Move", ' \
+                           '"attributes": {"object_id": 456, "movement": {"x": 1, "y": 1}}}]} '
+        deserialzied_scene = Scene.deserialize(json.loads(serialized_scene))
 
         assert deserialzied_scene == self.expected_deserialized_scene
 
     def test_failure(self) -> NoReturn:
-        serialized_scene = '{"entities": [{"type": "Object", "attributes": "{\\"id\\": 789, \\"name\\": \\"dummy\\", \\"position\\": {\\"x\\": 0, ' \
-                           '\\"y\\": 0}, \\"additional_positions\\": [], \\"state\\": \\"\\", \\"walkable\\": false, \\"tick\\": \\"\\", ' \
-                           '\\"on_death\\": \\"\\", \\"owner\\": \\"\\"}"}, {"type": "Move", "attributes": "{\\"object_id\\": 1011, \\"movement\\": {' \
-                           '\\"x\\": 1, \\"y\\": 1}}"}]}'
-        deserialzied_scene = Scene.deserialize(serialized_scene)
+        serialized_scene = '{"entities": [{"type": "Object", "attributes": {"id": 789, "name": "dummy", "position": {"x": 0, "y": 0}, ' \
+                           '"additional_positions": [], "state": "", "walkable": false, "tick": "", "on_death": "", "owner": ""}}, {"type": "Move", ' \
+                           '"attributes": {"object_id": 1011, "movement": {"x": 1, "y": 1}}}]} '
+        deserialzied_scene = Scene.deserialize(json.loads(serialized_scene))
 
         assert deserialzied_scene != self.expected_deserialized_scene

--- a/tests/serializable_test.py
+++ b/tests/serializable_test.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass, field
 from typing import List
 
@@ -23,7 +24,7 @@ class Dummy(Serializable):
 
 
 class TestSerializableSerialization:
-    expected_serialized_test_object = '{"exported_field": "DO_EXPORT_THAT+++", "complex_field": {\"nested_field\": \"THIS_SHOULD_BE_NESTED+++\"}}'
+    expected_serialized_test_object = '{"exported_field": "DO_EXPORT_THAT+++", "complex_field": {"nested_field": "THIS_SHOULD_BE_NESTED+++"}}'
 
     def test_success(self):
         test_object = Dummy()
@@ -48,14 +49,14 @@ class TestSerializableDeserialization:
     expected_deserialized_test_object.complex_field.nested_field += "+++"
 
     def test_success(self):
-        serialized_test_object = '{"exported_field": "DO_EXPORT_THAT+++", "complex_field": {\"nested_field\": \"THIS_SHOULD_BE_NESTED+++\"}}'
-        deserialized_test_object = Dummy.deserialize(serialized_test_object)
+        serialized_test_object = '{"exported_field": "DO_EXPORT_THAT+++", "complex_field": {"nested_field": "THIS_SHOULD_BE_NESTED+++"}}'
+        deserialized_test_object = Dummy.deserialize(json.loads(serialized_test_object))
 
         assert deserialized_test_object == self.expected_deserialized_test_object
 
     def test_failure(self):
-        serialized_test_object = '{"exported_field": "DO_EXPORT_THAT---", "complex_field": {\"nested_field\": \"THIS_SHOULD_BE_NESTED---\"}}'
-        deserialized_test_object = Dummy.deserialize(serialized_test_object)
+        serialized_test_object = '{"exported_field": "DO_EXPORT_THAT---", "complex_field": {"nested_field": "THIS_SHOULD_BE_NESTED---"}}'
+        deserialized_test_object = Dummy.deserialize(json.loads(serialized_test_object))
 
         assert deserialized_test_object != self.expected_deserialized_test_object
 
@@ -91,13 +92,13 @@ class TestSerializableListDeserialization:
 
     def test_success(self):
         serialized_test_list = '{"list": [{"number": 1}, {"number": 2}, {"number": 3}]}'
-        deserialized_test_list = DummyList.deserialize(serialized_test_list)
+        deserialized_test_list = DummyList.deserialize(json.loads(serialized_test_list))
 
         assert deserialized_test_list == self.expected_deserialized_test_list
 
     def test_failure(self):
         serialized_test_list = '{"list": [{"number": 4}, {"number": 5}, {"number": 6}]}'
-        deserialized_test_list = DummyList.deserialize(serialized_test_list)
+        deserialized_test_list = DummyList.deserialize(json.loads(serialized_test_list))
 
         assert deserialized_test_list != self.expected_deserialized_test_list
 


### PR DESCRIPTION
With current approach to serialization, when clients gets the data, he has to parse them as json twice, once the whole data, and the second time entity nested attributes. 
It is gimmicky and should be changed, so that one parsing is enough to get the whole data.