### PR TITLE
LNX-144 Actions should be required to use proper direction vectors

### DIFF
--- a/lynx/common/actions/common_requirements.py
+++ b/lynx/common/actions/common_requirements.py
@@ -1,6 +1,7 @@
 from lynx.common.object import Object
 from lynx.common.square import Square
 from lynx.common.vector import Vector
+from lynx.common.enums import Direction
 
 
 class CommonRequirements:
@@ -35,3 +36,11 @@ class CommonRequirements:
 				return True
 
 		return False
+
+	# TODO: Move, Push, Chop etc. should take argument of Direction type, not Vector type
+	# this means that serialization and deserialization have to be adapted to Enum
+	# when this is done, there is no need for this requirement
+	@staticmethod
+	def is_proper_direction(vector: Vector) -> bool:
+		direction_vectors = [Direction.NORTH.value, Direction.SOUTH.value, Direction.EAST.value, Direction.WEST.value]
+		return vector in direction_vectors

--- a/lynx/common/actions/move.py
+++ b/lynx/common/actions/move.py
@@ -1,7 +1,8 @@
+from typing import NoReturn
 from dataclasses import dataclass
 
 from lynx.common.actions.action import Action
-from lynx.common.actions.common_requirements import CommonRequirements
+from lynx.common.actions.common_requirements import CommonRequirements as Req
 from lynx.common.object import Object
 from lynx.common.vector import Vector
 from lynx.common.enums import Direction
@@ -18,8 +19,8 @@ class Move(Action):
 
     def satisfies_requirements(self, scene: 'Scene') -> bool:
         destination_position = scene.get_object_by_id(self.object_id).position + self.direction
-        return CommonRequirements.is_walkable(scene, destination_position)
+        return Req.is_walkable(scene, destination_position) and Req.is_proper_direction(self.direction)
 
-    def apply(self, scene: 'Scene') -> None:
+    def apply(self, scene: 'Scene') -> NoReturn:
         object: Object = scene.get_object_by_id(self.object_id)
         scene.move_object(object, self.direction)

--- a/lynx/common/actions/push.py
+++ b/lynx/common/actions/push.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, NoReturn
 from dataclasses import dataclass, field
 
 from lynx.common.vector import Vector
@@ -17,13 +17,6 @@ class Push(Action):
     direction: Vector = Direction.NORTH.value
     pushed_object_ids: List[int] = field(default_factory=list)  # needed for deserialization to know what objects are being pushed
 
-    def apply(self, scene: 'Scene') -> None:
-        pushed_position = scene.get_object_by_id(self.object_id).position + self.direction  # position of pushed object
-        objects_on_square = scene.get_objects_by_position(pushed_position)
-
-        for pushable_object in list(filter(lambda x: x.id in self.pushed_object_ids, objects_on_square)):
-            Move(pushable_object.id, self.direction).apply(scene)
-
     def satisfies_requirements(self, scene: 'Scene') -> bool:
         pushed_position = scene.get_object_by_id(self.object_id).position + self.direction  # position of pushed object
         destination_position = pushed_position + self.direction  # position to which the object is being pushed
@@ -33,4 +26,11 @@ class Push(Action):
             if Req.is_walkable(scene, destination_position) or Req.can_be_stacked(scene, destination_position, pushable_object.name):
                 self.pushed_object_ids.append(pushable_object.id)
 
-        return Req.is_in_range(scene, self.object_id, pushed_position, 1) and self.pushed_object_ids
+        return Req.is_in_range(scene, self.object_id, pushed_position, 1) and Req.is_proper_direction(self.direction) and self.pushed_object_ids
+
+    def apply(self, scene: 'Scene') -> NoReturn:
+        pushed_position = scene.get_object_by_id(self.object_id).position + self.direction  # position of pushed object
+        objects_on_square = scene.get_objects_by_position(pushed_position)
+
+        for pushable_object in list(filter(lambda x: x.id in self.pushed_object_ids, objects_on_square)):
+            Move(pushable_object.id, self.direction).apply(scene)

--- a/tests/common_requirements_test.py
+++ b/tests/common_requirements_test.py
@@ -6,10 +6,10 @@ from lynx.common.square import Square
 from lynx.common.vector import Vector
 from lynx.common.object import Object
 from lynx.common.scene import Scene
+from lynx.common.enums import Direction
 
 
 class TestIsWalkable:
-
     @patch('lynx.common.scene.Scene')
     def test_success(self, mock_scene) -> NoReturn:
         mock_square_at_destination = Square()
@@ -31,7 +31,7 @@ class TestIsWalkable:
         assert not result
 
 
-class TestIsStackable:
+class TestCanBeStacked:
     scene = Scene()
     dummy_object1 = Object(id=123, name="dummy", position=Vector(0, 0))
     scene.add_entity(dummy_object1)
@@ -44,3 +44,14 @@ class TestIsStackable:
 
     def test_no_object_failure(self) -> NoReturn:
         assert not CommonRequirements.can_be_stacked(self.scene, Vector(1, 0), "dummy")
+
+
+class TestIsProperDirection:
+    def test_north_vector_proper(self) -> NoReturn:
+        assert CommonRequirements.is_proper_direction(Direction.NORTH.value)
+
+    def test_south_vector_proper(self) -> NoReturn:
+        assert CommonRequirements.is_proper_direction(Vector(0, -1))
+
+    def test_huge_vector_improper(self) -> NoReturn:
+        assert not CommonRequirements.is_proper_direction(Vector(100, 100))

--- a/tests/move_test.py
+++ b/tests/move_test.py
@@ -46,7 +46,7 @@ class TestMoveRequirements:
     def test_success(self, mock_scene):
         dummy_action = Move(
             object_id=123,
-            direction=Vector(1, 1)
+            direction=Vector(1, 0)
         )
         walkable_square = Square()
         walkable_square.walkable = MagicMock(return_value=True)
@@ -62,13 +62,13 @@ class TestMoveApply:
         expected_scene = Scene()
         expected_dummy_object = Object(
             id=123, name="dummy", position=Vector(1, 1))
-        expected_dummy_action = Move(object_id=123, direction=Vector(1, 1))
+        expected_dummy_action = Move(object_id=123, direction=Vector(1, 0))
         expected_scene.add_entity(expected_dummy_object)
         expected_scene.add_entity(expected_dummy_action)
 
         scene = Scene()
-        dummy_object = Object(id=123, name="dummy", position=Vector(0, 0))
-        dummy_action = Move(object_id=123, direction=Vector(1, 1))
+        dummy_object = Object(id=123, name="dummy", position=Vector(0, 1))
+        dummy_action = Move(object_id=123, direction=Vector(1, 0))
         scene.add_entity(dummy_object)
         scene.add_entity(dummy_action)
         dummy_action.apply(scene)

--- a/tests/scene_test.py
+++ b/tests/scene_test.py
@@ -11,13 +11,13 @@ class TestSceneSerialization:
     expected_serialized_scene = '{"entities": [{"type": "Object", "attributes": {"id": 123, "name": "dummy", "position": {"x": ' \
                                 '0, "y": 0}, "additional_positions": [], "state": "", "walkable": false, "tick": "", ' \
                                 '"on_death": "", "owner": "", "pickable": false, "pushable": false}}, {"type": "Move", "attributes": {"object_id": 456, ' \
-                                '"direction": {"x": 1, "y": 1}}}], "pending_actions": []}'
+                                '"direction": {"x": 1, "y": 0}}}], "pending_actions": []}'
 
     def test_success(self) -> NoReturn:
         scene = Scene()
 
         dummy_object = Object(id=123, name="dummy", position=Vector(0, 0))
-        dummy_action = Move(object_id=456, direction=Vector(1, 1))
+        dummy_action = Move(object_id=456, direction=Vector(1, 0))
         scene.add_entity(dummy_object)
         scene.add_entity(dummy_action)
         serialized_scene = scene.serialize()
@@ -27,7 +27,7 @@ class TestSceneSerialization:
     def test_failure(self) -> NoReturn:
         scene = Scene()
         dummy_object = Object(id=789, name="dummy", position=Vector(0, 0))
-        dummy_action = Move(object_id=1011, direction=Vector(1, 1))
+        dummy_action = Move(object_id=1011, direction=Vector(1, 0))
         scene.add_entity(dummy_object)
         scene.add_entity(dummy_action)
         serialized_scene = scene.serialize()
@@ -38,14 +38,14 @@ class TestSceneSerialization:
 class TestSceneDeserialization:
     expected_deserialized_scene = Scene()
     dummy_object = Object(id=123, name="dummy", position=Vector(0, 0))
-    dummy_action = Move(object_id=456, direction=Vector(1, 1))
+    dummy_action = Move(object_id=456, direction=Vector(1, 0))
     expected_deserialized_scene.add_entity(dummy_object)
     expected_deserialized_scene.add_entity(dummy_action)
 
     def test_success(self) -> NoReturn:
         serialized_scene = '{"entities": [{"type": "Object", "attributes": {"id": 123, "name": "dummy", "position": {"x": 0, "y": 0}, ' \
                            '"additional_positions": [], "state": "", "walkable": false, "tick": "", "on_death": "", "owner": ""}}, {"type": "Move", ' \
-                           '"attributes": {"object_id": 456, "direction": {"x": 1, "y": 1}}}]} '
+                           '"attributes": {"object_id": 456, "direction": {"x": 1, "y": 0}}}]} '
         deserialzied_scene = Scene.deserialize(json.loads(serialized_scene))
 
         assert deserialzied_scene == self.expected_deserialized_scene
@@ -53,7 +53,7 @@ class TestSceneDeserialization:
     def test_failure(self) -> NoReturn:
         serialized_scene = '{"entities": [{"type": "Object", "attributes": {"id": 789, "name": "dummy", "position": {"x": 0, "y": 0}, ' \
                            '"additional_positions": [], "state": "", "walkable": false, "tick": "", "on_death": "", "owner": ""}}, {"type": "Move", ' \
-                           '"attributes": {"object_id": 1011, "direction": {"x": 1, "y": 1}}}]} '
+                           '"attributes": {"object_id": 1011, "direction": {"x": 1, "y": 0}}}]} '
         deserialzied_scene = Scene.deserialize(json.loads(serialized_scene))
 
         assert deserialzied_scene != self.expected_deserialized_scene


### PR DESCRIPTION
Added `is_proper_direction` requirement.
Players can no longer call actions with non-directional vectors e.g.
```
Push(100, 100)
Move(83884, 232)
```
They can only call them with directional vectors e.g.
```
Push(NORTH)
Move(0, 1)
```